### PR TITLE
Fix Next.js page type error in app/page.tsx

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,11 +17,13 @@ export default function Home() {
     queryFn: allPosts,
     queryKey: ["posts"],
   })
-  if (error) return error
-  if (isLoading) return "Loading....."
 
   return (
     <div>
+      <>
+        {error && error}
+        {isLoading && "Loading..."}
+      </>
       <AddPost />
       {data?.map((post) => (
         <Post


### PR DESCRIPTION
By executing "npm run build" command, we get the following error message :
 
![build_error](https://user-images.githubusercontent.com/44409901/224381218-e96571e6-9a9a-48d5-9b15-f947fa492d14.png)

This is due to the fact that the "error" and "loading" strings are not placed in the return of the component.